### PR TITLE
Fix toggling of JSON field instead of submitting

### DIFF
--- a/jsonsuit/templates/jsonsuit/widget.html
+++ b/jsonsuit/templates/jsonsuit/widget.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="jsonsuit" data-jsonsuit="{{ name }}">
-  <button class="toggle button" data-raw="{% trans 'Raw' %}" data-suit="{% trans 'Suit' %}">{% trans 'Raw' %}</button>
+  <button type="button" class="toggle button" data-raw="{% trans 'Raw' %}" data-suit="{% trans 'Suit' %}">{% trans 'Raw' %}</button>
   {{ textarea }}
   <div class="suit">
     <pre><code class="language-json" data-raw="{{ value }}"></code></pre>


### PR DESCRIPTION
Form doesn't submit on ENTER, likely because the buttons for the JSON toggler do not have a type attribute, then they are interpreted as submits by the browser... e.g. type="submit" is the default if type attribute is omitted...